### PR TITLE
Added check for MSVS2013 as GetVersionEx is marked as depricated.

### DIFF
--- a/ThirdParty/PSCommon/XnLib/Include/Win32/XnPlatformWin32.h
+++ b/ThirdParty/PSCommon/XnLib/Include/Win32/XnPlatformWin32.h
@@ -47,6 +47,9 @@
 // Includes
 //---------------------------------------------------------------------------
 #include <windows.h>
+#if _MSC_VER >= 1800
+#include <versionhelpers.h>
+#endif
 #include <stdlib.h>
 #include <stdio.h>
 #include <malloc.h>

--- a/ThirdParty/PSCommon/XnLib/Source/Win32/XnWin32OS.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/Win32/XnWin32OS.cpp
@@ -30,6 +30,61 @@
 //---------------------------------------------------------------------------
 // Code
 //---------------------------------------------------------------------------
+#if _MSC_VER >= 1800
+
+static XnStatus GetOSName(xnOSInfo* pOSInfo)
+{
+	if (IsWindows8Point1OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "Windows8Point1OrGreater\n");
+	else if (IsWindows8OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "Windows8\n");
+	else if (IsWindows7SP1OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "Windows7SP1\n");
+	else if (IsWindows7OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "Windows7\n");
+	else if (IsWindowsVistaSP2OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "VistaSP2\n");
+	else if (IsWindowsVistaSP1OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "VistaSP1\n");
+	else if (IsWindowsVistaOrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "Vista\n");
+	else if (IsWindowsXPSP3OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "XPSP3\n");
+	else if (IsWindowsXPSP2OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "XPSP2\n");
+	else if (IsWindowsXPSP1OrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "XPSP1\n");
+	else if (IsWindowsXPOrGreater())
+		sprintf(pOSInfo->csOSName, "%s", "XP\n");
+	else
+		sprintf(pOSInfo->csOSName, "%s", "Unknown win version\n");
+
+	return (XN_STATUS_OK);
+}
+
+#else
+
+static XnStatus GetOSName(xnOSInfo* pOSInfo)
+{
+	// Get OS Info
+	OSVERSIONINFOEX osVersionInfo;
+	osVersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
+
+	if (0 == GetVersionEx((LPOSVERSIONINFO)&osVersionInfo))
+	{
+		DWORD nErr = GetLastError();
+		xnLogWarning(XN_MASK_OS, "Failed getting OS version information. Error code: %d", nErr);
+		return XN_STATUS_ERROR;
+	}
+
+	sprintf(pOSInfo->csOSName, "%s", GetOSName(osVersionInfo));
+	if (osVersionInfo.szCSDVersion[0] != '\0')
+	{
+		strcat(pOSInfo->csOSName, " ");
+		strcat(pOSInfo->csOSName, osVersionInfo.szCSDVersion);
+	}
+}
+
 static const XnChar* GetOSName(OSVERSIONINFOEX& osVersionInfo)
 {
 	if (osVersionInfo.dwMajorVersion == 4)
@@ -133,6 +188,7 @@ static const XnChar* GetOSName(OSVERSIONINFOEX& osVersionInfo)
 
 	return "Unknown Windows Version";
 }
+#endif
 
 static void GetCPUName(XnChar* csName)
 {
@@ -195,20 +251,11 @@ XN_C_API XnStatus xnOSGetInfo(xnOSInfo* pOSInfo)
 	XN_VALIDATE_OUTPUT_PTR(pOSInfo);
 
 	// Get OS Info
-	OSVERSIONINFOEX osVersionInfo;
-	osVersionInfo.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
-	if (0 == GetVersionEx((LPOSVERSIONINFO)&osVersionInfo))
+	if (GetOSName(pOSInfo) != XN_STATUS_OK)
 	{
 		DWORD nErr = GetLastError();
 		xnLogWarning(XN_MASK_OS, "Failed getting OS version information. Error code: %d", nErr);
 		return XN_STATUS_ERROR;
-	}
-
-	sprintf(pOSInfo->csOSName, "%s", GetOSName(osVersionInfo));
-	if (osVersionInfo.szCSDVersion[0] != '\0')
-	{
-		strcat(pOSInfo->csOSName, " ");
-		strcat(pOSInfo->csOSName, osVersionInfo.szCSDVersion);
 	}
 
 	// Get CPU Info


### PR DESCRIPTION
Hi,

I tried to build this with visual studio 2013 express, but get a warning/error at the GetVersionEx.

I have implemented a new method to make use of the VersionHelpers, and a check if the VS is 1800 or above.

It seems that the xnOSGetInfo is not used at all, and I tried to use it in the NiViewer tool project, but I got some linking erros to InitializeSecurityDescriptor and SetSecurityDescriptorDacl which is part of the WINAPI.

Hence it is not checked for runtime errors.

Alternatively the xnOSGetInfo could just be removed?

Regards, Lars
