### PR TITLE
Fix kinect recording oni for ni te occipital

### DIFF
--- a/Source/Drivers/Kinect/DepthKinectStream.cpp
+++ b/Source/Drivers/Kinect/DepthKinectStream.cpp
@@ -442,6 +442,10 @@ void DepthKinectStream::notifyAllProperties()
 	getProperty(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, &size);
 	raisePropertyChanged(XN_STREAM_PROPERTY_D2S_TABLE, nBuff, size);
 
+	size = sizeof(PARAM_COEFF_VAL);
+	getProperty(XN_STREAM_PROPERTY_PARAM_COEFF, nBuff, &size);
+	raisePropertyChanged(XN_STREAM_PROPERTY_PARAM_COEFF, nBuff, size);
+
 	// Is this really necessary to save? Just in case.
 	OniBool nearMode;
 	size = sizeof(nearMode);


### PR DESCRIPTION
The ONI file recorded from Kinect sensor can't work with NiTE 2.2 because leak the property XN_STREAM_PROPERTY_PARAM_COEFF.
This patch fix this issue.
(https://github.com/OpenNI/OpenNI2/pull/80)

---

The pre-build dll could be download here
https://github.com/KHeresy/OpenNI2/releases/tag/KinectOniFix

Just replace original kinect.dll in OpenNI2\drivers
It should works for both OpenNI 2.2 and 2.3

And here is a small program to fix existed ONI files
https://github.com/VIML/oniFixer
It use the VirtualDeviceForOpenNI2 project (https://github.com/VIML/VirtualDeviceForOpenNI2), open the exist ONI file and create a virtual device to record it again with all required properties.
