### PR TITLE
fix error when building it in OS x 10.9 with libc++

### DIFF
--- a/ThirdParty/GL/glh/glh_convenience.h
+++ b/ThirdParty/GL/glh/glh_convenience.h
@@ -47,12 +47,6 @@
 // with opengl...
 
 
-
-// debugging hack...
-#include <iostream>
-
-using namespace std;
-
 #ifdef MACOS
 #include <OpenGL/gl.h>
 #else

--- a/ThirdParty/PSCommon/XnLib/ThirdParty/GL/glh/glh_convenience.h
+++ b/ThirdParty/PSCommon/XnLib/ThirdParty/GL/glh/glh_convenience.h
@@ -46,13 +46,6 @@
 // Convenience methods for using glh_linear objects
 // with opengl...
 
-
-
-// debugging hack...
-#include <iostream>
-
-using namespace std;
-
 #ifdef MACOS
 #include <OpenGL/gl.h>
 #else


### PR DESCRIPTION
Getting this errors when building Openni2 with libc++

```
clang++ -o ../../Bin/x64-Release/SimpleViewer ./../../Bin/Intermediate/x64-Release/SimpleViewer/Viewer.o ./../../Bin/Intermediate/x64-Release/SimpleViewer/main.o -arch i386 -arch x86_64 -framework OpenGL -framework GLUT  -L../../Bin/x64-Release -lOpenNI2 -Wl,-rpath ./
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:29: error: expected member name or ';' after declaration specifiers
    virtual bool equivalent(int __code, const error_condition& __condition) const _NOEXCEPT;
    ~~~~~~~~~~~~            ^
../../../ThirdParty/GL/glh/glh_linear.h:80:36: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                   ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:29: error: expected ')'
../../../ThirdParty/GL/glh/glh_linear.h:80:36: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:18: note: to match this '('
    virtual bool equivalent(int __code, const error_condition& __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:35: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                  ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:18: error: expected ')'
    virtual bool equivalent(int __code, const error_condition& __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:57: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                                        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:18: note: to match this '('
../../../ThirdParty/GL/glh/glh_linear.h:80:34: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                 ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:18: error: expected ')'
    virtual bool equivalent(int __code, const error_condition& __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:83: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                                                                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:383:18: note: to match this '('
../../../ThirdParty/GL/glh/glh_linear.h:80:33: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:29: error: expected member name or ';' after declaration specifiers
    virtual bool equivalent(const error_code& __code, int __condition) const _NOEXCEPT;
    ~~~~~~~~~~~~            ^
../../../ThirdParty/GL/glh/glh_linear.h:80:36: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                   ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:29: error: expected ')'
../../../ThirdParty/GL/glh/glh_linear.h:80:36: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                   ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:18: note: to match this '('
    virtual bool equivalent(const error_code& __code, int __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:35: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                  ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:18: error: expected ')'
    virtual bool equivalent(const error_code& __code, int __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:57: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                                        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:18: note: to match this '('
../../../ThirdParty/GL/glh/glh_linear.h:80:34: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                 ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:18: error: expected ')'
    virtual bool equivalent(const error_code& __code, int __condition) const _NOEXCEPT;
                 ^
../../../ThirdParty/GL/glh/glh_linear.h:80:83: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                                                                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:384:18: note: to match this '('
../../../ThirdParty/GL/glh/glh_linear.h:80:33: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:567:27: error: expected unqualified-id
    return __x.category().equivalent(__x.value(), __y)
                          ^
../../../ThirdParty/GL/glh/glh_linear.h:80:33: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                ^
In file included from NiViewer.cpp:75:
In file included from ../../../ThirdParty/GL/glh/glh_glut2.h:61:
In file included from ../../../ThirdParty/GL/glh/glh_convenience.h:52:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/iostream:38:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/ios:216:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__locale:18:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/mutex:176:
In file included from /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/__mutex_base:16:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../lib/c++/v1/system_error:568:27: error: expected unqualified-id
        || __y.category().equivalent(__x, __y.value());
                          ^
../../../ThirdParty/GL/glh/glh_linear.h:80:33: note: expanded from macro 'equivalent'
#define     equivalent(a,b)     (((a < b + GLH_EPSILON) && (a > b - GLH_EPSILON)) ? true : false)
                                ^
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C Samples/ClosestPointViewer
mkdir -p ../../Bin/Intermediate/x64-Release/ClosestPointViewer
clang++ -x c++ -c -arch i386 -arch x86_64 -msse3 -DMACOS -Wall -O2 -DNDEBUG -I../../Include -I../ -I../../ThirdParty/GL/ -I../Common  -fPIC -fvisibility=hidden -Werror -o ../../Bin/Intermediate/x64-Release/ClosestPointViewer/Viewer.o Viewer.cpp
clang++ -o ../../Bin/x64-Release/MultiDepthViewer ./../../Bin/Intermediate/x64-Release/MultiDepthViewer/Viewer.o ./../../Bin/Intermediate/x64-Release/MultiDepthViewer/main.o -arch i386 -arch x86_64 -framework OpenGL -framework GLUT  -L../../Bin/x64-Release -lOpenNI2 -Wl,-rpath ./
clang++ -x c++ -c -arch i386 -arch x86_64 -msse3 -Wall -O2 -DNDEBUG -I. -IInclude -I../../../Include -I../../../ThirdParty/PSCommon/XnLib/Include -I../../../ThirdParty/LibJPEG -I../../DepthUtils -I/opt/local/include  -fPIC -fvisibility=hidden -Werror -o ../../../Bin/Intermediate/x64-Release/libPS1080.dylib/XnFrameStreamProcessor.o Sensor/XnFrameStreamProcessor.cpp
/Applications/Xcode.app/Contents/Developer/usr/bin/make -C Samples/MWClosestPointApp
mkdir -p ../../Bin/Intermediate/x64-Release/MWClosestPointApp
clang++ -x c++ -c -arch i386 -arch x86_64 -msse3 -Wall -O2 -DNDEBUG -I../../Include -I../MWClosestPoint -I../Common  -fPIC -fvisibility=hidden -Werror -o ../../Bin/Intermediate/x64-Release/MWClosestPointApp/main.o main.cpp
10 errors generated.
```
