### PR TITLE
Added a missing -lpthread flag to one Makefile

### DIFF
--- a/Source/Tools/NiViewer/Makefile
+++ b/Source/Tools/NiViewer/Makefile
@@ -26,7 +26,7 @@ else
 endif
 
 LIB_DIRS  += ../../../ThirdParty/PSCommon/XnLib/Bin/$(PLATFORM)-$(CFG)
-USED_LIBS += OpenNI2 XnLib
+USED_LIBS += OpenNI2 XnLib pthread
 
 EXE_NAME = NiViewer
 


### PR DESCRIPTION
I had problem while compiling OpenNI2 in my Ubuntu 14.04 box. I just cloned the repo at <a ref="https://github.com/occipital/OpenNI2/commit/6d02884b53011a95477a85a462b9217643c6788a">commit 6d02884</a> (master branch), cd'ed into the project root directory and issued 'make' after installing all dependencies listed in the README.md file. Then I got this error in the terminal

<code>
g++ -o ../../../Bin/x64-Release/NiViewer ./../../../Bin/Intermediate/x64-Release/NiViewer/Device.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Draw.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Keyboard.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Menu.o ./../../../Bin/Intermediate/x64-Release/NiViewer/MouseInput.o ./../../../Bin/Intermediate/x64-Release/NiViewer/NiViewer.o ./../../../Bin/Intermediate/x64-Release/NiViewer/Capture.o -L../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release -L../../../Bin/x64-Release -lglut -lGL -lOpenNI2 -lXnLib -Wl,-rpath ./
</code><br>
<code>
/usr/bin/ld: ../../../ThirdParty/PSCommon/XnLib/Bin/x64-Release/libXnLib.a(XnLinuxMutex.o): undefined reference to symbol 'pthread_mutexattr_settype@@GLIBC_2.2.5'
</code><br>
<code>
//lib/x86_64-linux-gnu/libpthread.so.0: error adding symbols: DSO missing from command line
</code><br>
<code>
collect2: error: ld returned 1 exit status
</code>

which suggests a missing <code>-lpthread</code> option somewhere in the compilation chain. Based on the line above I added <code>-lpthread</code> to the <code>USED_LIBS</code> variable in the Makefile in <code>Source/Tools/NiViewer</code> and issued make again in the project root directory. This time, everything worked. This issue actually appeared before in the <a href="https://github.com/OpenNI/OpenNI2">old OpenNI repo</a> (before being forked by Occipital) as <a href="https://github.com/OpenNI/OpenNI2/issues/47">issue no 47</a> and the solution was just like I did.

I'm sorry for the poorly displayed error message. I couldn't figure out how to put it in a horizontal scroll.
