### PR TITLE
Use parentheses with print in python

### DIFF
--- a/Packaging/Harvest.py
+++ b/Packaging/Harvest.py
@@ -335,7 +335,7 @@ $(OUTPUT_FILE): copy-redist
             shutil.copy(os.path.join(self.rootDir, 'Packaging', 'Linux', 'primesense-usb.rules'), self.outDir)
 
 if len(sys.argv) < 3:
-    print 'Usage: ' + sys.argv[0] + ' <OutDir> <x86|x64|Arm>'
+    print('Usage: ' + sys.argv[0] + ' <OutDir> <x86|x64|Arm>')
     exit(1)
     
 rootDir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))

--- a/Packaging/ReleaseVersion.py
+++ b/Packaging/ReleaseVersion.py
@@ -32,7 +32,7 @@ import stat
 import UpdateVersion
 
 if len(sys.argv) < 2 or sys.argv[1] in ('-h','--help'):
-    print "usage: " + sys.argv[0] + " <x86|x64|Arm|android> [UpdateVersion]"
+    print("usage: " + sys.argv[0] + " <x86|x64|Arm|android> [UpdateVersion]")
     sys.exit(1)
     
 plat = sys.argv[1]
@@ -89,14 +89,14 @@ def calc_jobs_number():
 
 # Create installer
 strVersion = UpdateVersion.getVersionName()
-print "Creating installer for OpenNI " + strVersion + " " + plat
+print("Creating installer for OpenNI " + strVersion + " " + plat)
 finalDir = "Final"
 if not os.path.isdir(finalDir):
     os.mkdir(finalDir)
     
 if plat == 'android':
     if not 'NDK_ROOT' in os.environ:
-        print 'Please define NDK_ROOT!'
+        print('Please define NDK_ROOT!')
         sys.exit(2)
 
     ndkDir = os.environ['NDK_ROOT']
@@ -115,7 +115,7 @@ if plat == 'android':
     shutil.copy('../Application.mk', buildDir + '/jni')
     rc = subprocess.call([ ndkDir + '/ndk-build', '-C', buildDir, '-j8' ])
     if rc != 0:
-        print 'Build failed!'
+        print('Build failed!')
         sys.exit(3)
 
     finalFile = finalDir + '/' + outputDir + '.tar'
@@ -174,12 +174,12 @@ elif platform.system() == 'Linux' or platform.system() == 'Darwin':
     os.remove(origDir + '/build.release.' + plat + '.log')
     
 else:
-    print "Unknown OS"
+    print("Unknown OS")
     sys.exit(2)
     
 # also copy Release Notes and CHANGES documents
 shutil.copy('../ReleaseNotes.txt', finalDir)
 shutil.copy('../CHANGES.txt', finalDir)
     
-print "Installer can be found under: " + finalDir
-print "Done"
+print("Installer can be found under: " + finalDir)
+print("Done")

--- a/Packaging/UpdateVersion.py
+++ b/Packaging/UpdateVersion.py
@@ -58,7 +58,7 @@ def update():
         print ("Illegal build version")
         sys.exit()
 
-    print "Going to update files to version: " + getVersionString()
+    print("Going to update files to version: " + getVersionString())
 
     update_self_defs("./UpdateVersion.py")
     update_src_ver_defs("../Include/OniVersion.h")

--- a/ThirdParty/PSCommon/BuildSystem/BuildJavaWindows.py
+++ b/ThirdParty/PSCommon/BuildSystem/BuildJavaWindows.py
@@ -5,7 +5,7 @@ import shutil
 
 # parse command line
 if len(sys.argv) < 5:
-    print "usage: " + sys.argv[0] + " <x86|x64> <BinDir> <SourceDir> <Name> [NeededJarFiles] [MainClass]"
+    print("usage: " + sys.argv[0] + " <x86|x64> <BinDir> <SourceDir> <Name> [NeededJarFiles] [MainClass]")
     exit(1)
 
 platform_string = ""
@@ -14,7 +14,7 @@ if sys.argv[1] == "" or sys.argv[1] == "x86":
 elif sys.argv[1] == "x64":
     platform_string = "x64"
 else:
-    print 'First argument must be "x86", "x64" or empty (x86)'
+    print('First argument must be "x86", "x64" or empty (x86)')
     exit(1)
     
 bin_dir = os.path.abspath(sys.argv[2])
@@ -37,7 +37,7 @@ BATCH_FILE = os.path.join(RELEASE_DIR, proj_name + '.bat')
 # make sure JAVA_HOME is set
 JAVA_HOME = os.path.expandvars("$JAVA_HOME")
 if JAVA_HOME == "":
-    print "JAVA_HOME is not set!"
+    print("JAVA_HOME is not set!")
     exit(1)
     
 CLASS_PATH = os.path.expandvars("$CLASSPATH")
@@ -106,7 +106,7 @@ shutil.copy(JAR_FILE, DEBUG_DIR)
     
 # create batch file (by default, windows does not open a console when double-clicking jar files)
 if main_class != "":
-    print "Creating batch file..."
+    print("Creating batch file...")
     batch = open(BATCH_FILE, 'w')
     batch.write('java -Xmx768m -jar ' + proj_name + '.jar\n')
     batch.close()


### PR DESCRIPTION
In python3, the print function needs parentheses.
And for environments using python3 by default, it is more convenient
to have python code compatible with python3.
This should fix #38.  