### PR TITLE
Fix seeking behaviour

### DIFF
--- a/Source/Core/OniDevice.cpp
+++ b/Source/Core/OniDevice.cpp
@@ -209,6 +209,8 @@ void Device::notifyAllProperties()
 }
 OniStatus Device::invoke(int commandId, void* data, int dataSize)
 {
+	Device::Seek seek;
+
 	if (commandId == ONI_DEVICE_COMMAND_SEEK)
 	{
 		if (dataSize != sizeof(OniSeek))
@@ -217,17 +219,12 @@ OniStatus Device::invoke(int commandId, void* data, int dataSize)
 		}
 
 		// Change seek's stream handle.
-		Device::Seek seek;
 		OniSeek* pSeek = (OniSeek*)data;
 		seek.frameId = pSeek->frameIndex;
 		seek.pStream = ((_OniStream*)pSeek->stream)->pStream->getHandle();
-
-		// Update data to point to new structure.
-		data = &seek;
-		dataSize = sizeof(seek);
 	}
 
-	return m_driverHandler.deviceInvoke(m_deviceHandle, commandId, data, dataSize);
+	return m_driverHandler.deviceInvoke(m_deviceHandle, commandId, &seek, sizeof(seek));
 }
 OniBool Device::isCommandSupported(int commandId)
 {

--- a/Source/Drivers/OniFile/PlayerDevice.cpp
+++ b/Source/Drivers/OniFile/PlayerDevice.cpp
@@ -655,7 +655,13 @@ void PlayerDevice::MainLoop()
 
 			// Seek the frame ID for first source (seek to (frame ID-1) so next read frame is frameId).
 			PlayerSource* pSource = m_seek.pStream->GetSource();
-			XnStatus xnrc = m_player.SeekToFrame(pSource->GetNodeName(), m_seek.frameId, XN_PLAYER_SEEK_SET);
+
+			XnStatus xnrc;
+			if(pSource) {
+				xnrc = m_player.SeekToFrame(pSource->GetNodeName(), m_seek.frameId, XN_PLAYER_SEEK_SET);
+			}else{
+				xnrc = XN_STATUS_ERROR;
+			}
 
 			if (xnrc != XN_STATUS_OK)
 			{

--- a/Source/Tools/NiViewer/Device.cpp
+++ b/Source/Tools/NiViewer/Device.cpp
@@ -487,7 +487,7 @@ void seekStream(openni::VideoStream* pStream, openni::VideoFrameRef* pCurFrame, 
 		}
 
 		// the new frameId might be different than expected (due to clipping to edges)
-		frameId = pCurFrame->getFrameIndex();
+		frameId = pCurFrame->isValid()? pCurFrame->getFrameIndex() : 0;
 
 		displayMessage("Current frame: %u/%u", frameId, numberOfFrames);
 	}
@@ -516,7 +516,7 @@ void seekFrame(int nDiff)
 	if (pStream == NULL)
 		return;
 
-	int frameId = pCurFrame->getFrameIndex();
+	int frameId = pCurFrame->isValid() ? pCurFrame->getFrameIndex() : 0;
 	// Calculate the new frame ID
 	frameId = (frameId + nDiff < 1) ? 1 : frameId + nDiff;
 


### PR DESCRIPTION
I discovered that the cause of intermittent seeking behaviour across machines and platforms was due to using the address of an out-of-scope stack variable. This PR contains three patches to fix and robustify seeking behaviour.