### PR TITLE
Use parentheses with print in python

### DIFF
--- a/Packaging/Harvest.py
+++ b/Packaging/Harvest.py
@@ -467,7 +467,7 @@ $(OUTPUT_FILE): copy-redist
 
 if __name__ == '__main__':
     if len(sys.argv) < 3:
-        print 'Usage: ' + sys.argv[0] + ' <OutDir> <x86|x64|Arm|Android>'
+        print('Usage: ' + sys.argv[0] + ' <OutDir> <x86|x64|Arm|Android>')
         exit(1)
 
     rootDir = os.path.abspath(os.path.join(os.path.dirname(sys.argv[0]), '..'))

--- a/Packaging/ReleaseVersion.py
+++ b/Packaging/ReleaseVersion.py
@@ -20,6 +20,8 @@
 #*  limitations under the License.                                           *
 #*                                                                           *
 #****************************************************************************/
+from __future__ import print_function
+
 import os
 import re
 import sys
@@ -33,7 +35,7 @@ import UpdateVersion
 from Harvest import Harvest
 
 if len(sys.argv) < 2 or sys.argv[1] in ('-h','--help'):
-    print "usage: " + sys.argv[0] + " <x86|x64|Arm|Android> [UpdateVersion]"
+    print("usage: " + sys.argv[0] + " <x86|x64|Arm|Android> [UpdateVersion]")
     sys.exit(1)
 
 plat = sys.argv[1]
@@ -56,7 +58,7 @@ def check_call(cmd, outputFile = None):
 
     rc = subprocess.call(cmd, shell=useShell, stdout=outputFile, stderr=outputFile)
     if rc != 0:
-        print 'Failed to execute command: ' + str(cmd)
+        print('Failed to execute command: ' + str(cmd))
         sys.exit(9)
 
 def get_reg_values(reg_key, value_list):
@@ -101,11 +103,11 @@ def calc_jobs_number():
 
 def build_android_project(path, outputFile, target = 'release'):
     if not 'NDK_HOME' in os.environ:
-        print 'Please define NDK_HOME!'
+        print('Please define NDK_HOME!')
         sys.exit(2)
 
     if not 'ANDROID_HOME' in os.environ:
-        print 'Please define ANDROID_HOME!'
+        print('Please define ANDROID_HOME!')
         sys.exit(2)
 
     sdkDir = os.environ['ANDROID_HOME']
@@ -122,29 +124,29 @@ def build_android():
     # build all projects
     android_projects = libraries + samples + tools
     # clean all
-    print 'Cleaning...'
+    print('Cleaning...')
     for proj in android_projects:
         logFile.write('**** Cleaning ' + proj + "...****\n")
         build_android_project(os.path.join('..', proj), outputFile=logFile, target='clean')
     # and build all
     for proj in android_projects:
         logFile.write('**** Building ' + proj + "...****\n")
-        print 'Building ' + proj + '...',
+        print('Building ' + proj + '...', end=" ")
         build_android_project(os.path.join('..', proj), outputFile=logFile)
-        print 'OK'
+        print('OK')
 
     # build documentation
-    print 'Creating C++ documentation...',
+    print('Creating C++ documentation...', end=" ")
     check_call([os.path.join('..', 'Source', 'Documentation', 'Runme.py')], outputFile=logFile)
-    print 'OK'
+    print('OK')
 
-    print 'Creating java documentation...',
+    print('Creating java documentation...', end=" ")
     build_android_project('../Wrappers/java', outputFile=logFile, target='javadoc')
-    print 'OK'
+    print('OK')
 
 # Create installer
 strVersion = UpdateVersion.getVersionName()
-print "Creating installer for OpenNI " + strVersion + " " + plat
+print("Creating installer for OpenNI " + strVersion + " " + plat)
 finalDir = "Final"
 if not os.path.isdir(finalDir):
     os.mkdir(finalDir)
@@ -204,12 +206,12 @@ elif platform.system() == 'Linux' or platform.system() == 'Darwin':
     os.remove(origDir + '/build.release.' + plat + '.log')
 
 else:
-    print "Unknown OS"
+    print("Unknown OS")
     sys.exit(2)
 
 # also copy Release Notes and CHANGES documents
 shutil.copy('../ReleaseNotes.txt', finalDir)
 shutil.copy('../CHANGES.txt', finalDir)
 
-print "Installer can be found under: " + finalDir
-print "Done"
+print("Installer can be found under: " + finalDir)
+print("Done")

--- a/Packaging/UpdateVersion.py
+++ b/Packaging/UpdateVersion.py
@@ -60,7 +60,7 @@ def update():
         print ("Illegal build version")
         sys.exit()
 
-    print "Going to update files to version: " + getVersionString()
+    print("Going to update files to version: " + getVersionString())
 
     update_self_defs("./UpdateVersion.py")
     update_src_ver_defs("../Include/OniVersion.h")

--- a/ThirdParty/PSCommon/BuildSystem/BuildJavaWindows.py
+++ b/ThirdParty/PSCommon/BuildSystem/BuildJavaWindows.py
@@ -25,7 +25,7 @@ import shutil
 
 # parse command line
 if len(sys.argv) < 5:
-    print "usage: " + sys.argv[0] + " <x86|x64> <BinDir> <SourceDir> <Name> [NeededJarFiles] [MainClass]"
+    print("usage: " + sys.argv[0] + " <x86|x64> <BinDir> <SourceDir> <Name> [NeededJarFiles] [MainClass]")
     exit(1)
 
 platform_string = ""
@@ -34,7 +34,7 @@ if sys.argv[1] == "" or sys.argv[1] == "x86":
 elif sys.argv[1] == "x64":
     platform_string = "x64"
 else:
-    print 'First argument must be "x86", "x64" or empty (x86)'
+    print('First argument must be "x86", "x64" or empty (x86)')
     exit(1)
     
 bin_dir = os.path.abspath(sys.argv[2])
@@ -57,7 +57,7 @@ BATCH_FILE = os.path.join(RELEASE_DIR, proj_name + '.bat')
 # make sure JAVA_HOME is set
 JAVA_HOME = os.path.expandvars("$JAVA_HOME")
 if JAVA_HOME == "":
-    print "JAVA_HOME is not set!"
+    print("JAVA_HOME is not set!")
     exit(1)
     
 CLASS_PATH = os.path.expandvars("$CLASSPATH")
@@ -126,7 +126,7 @@ shutil.copy(JAR_FILE, DEBUG_DIR)
     
 # create batch file (by default, windows does not open a console when double-clicking jar files)
 if main_class != "":
-    print "Creating batch file..."
+    print("Creating batch file...")
     batch = open(BATCH_FILE, 'w')
     batch.write('java -Xmx768m -jar ' + proj_name + '.jar %*\n')
     batch.close()

--- a/Wrappers/java/jni/UpdateHeaders.py
+++ b/Wrappers/java/jni/UpdateHeaders.py
@@ -28,7 +28,7 @@ import glob
 import sys
 
 if len(sys.argv) < 2 or sys.argv[1] in ('-h', '--help') or not sys.argv[1] in('android', 'java'):
-    print 'usage: ' + sys.argv[0] + ' <android|java>'
+    print('usage: ' + sys.argv[0] + ' <android|java>')
     sys.exit(1)
 
 type = sys.argv[1]
@@ -56,7 +56,7 @@ else:
     JAVAH = 'javah'
 
 cmd = [JAVAH, '-classpath', class_dir] + classes
-print cmd
+print(cmd)
 subprocess.check_call(cmd)
 
 # now create the methods.inl file


### PR DESCRIPTION
In python3, the print function needs parentheses.
And for environments using python3 by default, it is more convenient
to have python code compatible with python3.

See #39 and #38