### PR TITLE
Update org_openni_NativeMethods.cpp

### DIFF
--- a/Wrappers/java/OpenNI.jni/org_openni_NativeMethods.cpp
+++ b/Wrappers/java/OpenNI.jni/org_openni_NativeMethods.cpp
@@ -659,7 +659,7 @@ JNIEXPORT jint JNICALL Java_org_openni_NativeMethods_oniGetDeviceList
 				  uriObj, vendorObj, nameObj, m_pDeviceInfos[i].usbVendorId, m_pDeviceInfos[i].usbProductId);
 			  jclass vectorCls = (*env).FindClass("java/util/List");
 			  jmethodID methodId = (*env).GetMethodID(vectorCls, "add", "(Ljava/lang/Object;)Z");
-			  (*env).CallVoidMethod(deviceListObj, methodId, deviceInfObj);
+			  (*env).CallBooleanMethod(deviceListObj, methodId, deviceInfObj);
 
 		  }
 	  }	  


### PR DESCRIPTION
List.add(object) returns boolean, not void!
See http://stackoverflow.com/a/17297094

Not changing this causes the following error:

02-17 20:06:09.617 W/dalvikvm(4962): JNI WARNING: expected return type 'V'
02-17 20:06:09.617 W/dalvikvm(4962): calling Ljava/util/List;.add (Ljava/lang/Object;)Z
02-17 20:06:09.617 W/dalvikvm(4962): in Lorg/openni/NativeMethods;.oniGetDeviceList:(Ljava/util/List;)I (CallVoidMethodV)
with the stack
02-17 20:06:09.632 I/dalvikvm(4962): #06 pc 00002a58 /system/lib/libOpenNI2.jni.so (_JNIEnv::CallVoidMethod(_jobject, _jmethodID, ...)+15)
02-17 20:06:09.632 I/dalvikvm(4962): #07 pc 00003b88 /system/lib/libOpenNI2.jni.so (Java_org_openni_NativeMethods_oniGetDeviceList+179)