### PR TITLE
Improved performance by using FrameArrived events to avoid busy waiting

### DIFF
--- a/Source/Drivers/Kinect2/Kinect2StreamImpl.h
+++ b/Source/Drivers/Kinect2/Kinect2StreamImpl.h
@@ -4,12 +4,7 @@
 #include "BaseKinect2Stream.h"
 #include "XnList.h"
 
-struct IKinectSensor;
-struct ICoordinateMapper;
-struct IFrameDescription;
-struct IColorFrameReader;
-struct IDepthFrameReader;
-struct IInfraredFrameReader;
+#include <Kinect.h>
 
 namespace kinect2_device
 {
@@ -71,6 +66,8 @@ namespace kinect2_device
       OniImageRegistrationMode m_imageRegistrationMode;
       OniVideoMode m_videoMode;
       xnl::List<BaseKinect2Stream*> m_streamList;
+
+      WAITABLE_HANDLE m_hWaitable;
 
       // Thread
       bool m_running;


### PR DESCRIPTION
Without this patch, the Kinect2 driver basically does busy waiting for new frames on three threads simultaneously, always taking all available CPU cycles. 
With this patch, the three threads sleep until the Kinect SDK sends a `FrameArrived` event for the corresponding `FrameReader`, using up way less CPU cycles.
