### PR TITLE
Fix pointer casts causing SIGBUS on arm on Android.

### DIFF
--- a/Source/Drivers/OniFile/DataRecords.cpp
+++ b/Source/Drivers/OniFile/DataRecords.cpp
@@ -721,7 +721,9 @@ void IntPropRecord::SetValue(XnUInt64 nValue)
 XnUInt64 IntPropRecord::GetValue() const
 {
 	XN_ASSERT(GetPropDataSize() == sizeof(XnUInt64));
-	return *(XnUInt64*)GetPropData();
+	XnUInt64 data;
+	memcpy(&data, GetPropData(), sizeof(XnUInt64));
+	return data;
 }
 
 XnStatus IntPropRecord::AsString(XnChar* strDest, XnUInt32 nSize, XnUInt32& nCharsWritten)
@@ -762,7 +764,9 @@ void RealPropRecord::SetValue(XnDouble dValue)
 XnDouble RealPropRecord::GetValue() const
 {
 	XN_ASSERT(GetPropDataSize() == sizeof(XnDouble));
-	return *(XnDouble*)GetPropData();
+	XnDouble data;
+	memcpy(&data, GetPropData(), sizeof(XnDouble));
+	return data;
 }
 
 XnStatus RealPropRecord::AsString(XnChar* strDest, XnUInt32 nSize, XnUInt32& nCharsWritten)

--- a/Source/Drivers/OniFile/PlayerDevice.cpp
+++ b/Source/Drivers/OniFile/PlayerDevice.cpp
@@ -1006,10 +1006,11 @@ XnStatus XN_CALLBACK_TYPE PlayerDevice::OnNodeGeneralPropChanged(void* pCookie, 
 		}
 		else if (strcmp(strPropName, XN_PROP_FIELD_OF_VIEW) == 0)
 		{
-			XnFieldOfView* pFieldOfView = (XnFieldOfView*)pBuffer;
+			XnFieldOfView pFieldOfView;
+			memcpy(&pFieldOfView, pBuffer, sizeof(XnFieldOfView));
 
 			// Set the HFOV.
-			float fov = (float)pFieldOfView->fHFOV;
+			float fov = (float)pFieldOfView.fHFOV;
 			rc = pSource->SetProperty(ONI_STREAM_PROPERTY_HORIZONTAL_FOV, &fov, sizeof(fov));
 			if (rc != ONI_STATUS_OK)
 			{
@@ -1018,7 +1019,7 @@ XnStatus XN_CALLBACK_TYPE PlayerDevice::OnNodeGeneralPropChanged(void* pCookie, 
 			else
 			{
 				// Set the VFOV.
-				fov = (float)pFieldOfView->fVFOV;
+				fov = (float)pFieldOfView.fVFOV;
 				rc = pSource->SetProperty(ONI_STREAM_PROPERTY_VERTICAL_FOV, &fov, sizeof(fov));
 				if (rc != ONI_STATUS_OK)
 				{


### PR DESCRIPTION
These unaligned reads cause a SIGBUS on armeabi-v7a. memcpy fixes the problem.