### PR TITLE
Fix -Werror=format-security for the Android logger

### DIFF
--- a/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp
@@ -58,7 +58,7 @@ void XnLogAndroidWriter::WriteEntry(const XnLogEntry* pEntry)
 #ifdef XN_PLATFORM_ANDROID_OS
 	ALOGE("OpenNI2: %s\n", pEntry->strMessage);
 #else
-	__android_log_print(OpenNISeverityToAndroid(pEntry->nSeverity), "OpenNI", pEntry->strMessage);
+	__android_log_print(OpenNISeverityToAndroid(pEntry->nSeverity), "OpenNI", "%s", pEntry->strMessage);
 #endif
 }
 


### PR DESCRIPTION
This fixes the following error:


jni/OpenNI2/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp: In member function 'virtual void XnLogAndroidWriter::WriteEntry(const XnLogEntry*)':
jni/OpenNI2/ThirdParty/PSCommon/XnLib/Source/XnLogAndroidWriter.cpp:61:94: error: format not a string literal and no format arguments [-Werror=format-security]
  __android_log_print(OpenNISeverityToAndroid(pEntry->nSeverity), "OpenNI", pEntry->strMessage);
                                                                                              ^