### PR TITLE
Stop ErrorLogger from from overflowing its internal buffer

### DIFF
--- a/ThirdParty/PSCommon/XnLib/Source/Win32/XnWin32Strings.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/Win32/XnWin32Strings.cpp
@@ -252,9 +252,11 @@ XN_C_API XnStatus xnOSStrFormatV(XnChar* cpDestString, const XnUInt32 nDestLengt
 
 	// nRes is the number of bytes written, not including NULL termination
 
-	if ((nRes == -1) ||	// string was truncated
-		(nRes == (XnInt32)nDestLength && cpDestString[nRes] != '\0')) // no space for the NULL termination
+	if ( nRes < 0 // encoding error 
+	  || nRes > (XnInt32)nDestLength // string was truncated
+	  || (nRes == (XnInt32)nDestLength && cpDestString[nRes] != '\0')) // no space for the NULL termination
 	{
+    *pnCharsWritten = nDestLength;
 		return (XN_STATUS_INTERNAL_BUFFER_TOO_SMALL);
 	}
 

--- a/ThirdParty/PSCommon/XnLib/Source/XnErrorLogger.cpp
+++ b/ThirdParty/PSCommon/XnLib/Source/XnErrorLogger.cpp
@@ -44,7 +44,7 @@ namespace xnl
 	{
 		SingleBuffer* pBuffer = getBuffer();
 
-		if (pBuffer->m_currentEnd > ms_bufferSize)
+		if (pBuffer->m_currentEnd >= ms_bufferSize)
 			return;
 
 		pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\t';
@@ -52,30 +52,41 @@ namespace xnl
 
 		va_list args;
 		va_start(args, cpFormat);
-		xnOSStrFormatV(pBuffer->m_errorBuffer+pBuffer->m_currentEnd, ms_bufferSize-pBuffer->m_currentEnd, &charsWritten, cpFormat, args);
+		XnStatus status = xnOSStrFormatV(pBuffer->m_errorBuffer+pBuffer->m_currentEnd, ms_bufferSize-pBuffer->m_currentEnd, &charsWritten, cpFormat, args);
 		va_end(args);
 
-		pBuffer->m_currentEnd += charsWritten;
-		pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\n';
-		pBuffer->m_errorBuffer[pBuffer->m_currentEnd] = '\0';
-
+		if (status == XN_STATUS_OK)
+		{
+			pBuffer->m_currentEnd += charsWritten;
+			pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\n';
+			pBuffer->m_errorBuffer[pBuffer->m_currentEnd] = '\0';
+		}
+		else
+		{
+			pBuffer->m_currentEnd += charsWritten;
+		}
 	}
 
 	void ErrorLogger::AppendV(const XnChar* cpFormat, va_list args)
 	{
 		SingleBuffer* pBuffer = getBuffer();
 
-		if (pBuffer->m_currentEnd > ms_bufferSize)
+		if (pBuffer->m_currentEnd >= ms_bufferSize)
 			return;
+
 		pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\t';
 		unsigned int charsWritten;
 
-		xnOSStrFormatV(pBuffer->m_errorBuffer+pBuffer->m_currentEnd, ms_bufferSize-pBuffer->m_currentEnd, &charsWritten, cpFormat, args);
-
-		pBuffer->m_currentEnd += charsWritten;
-		pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\n';
-		pBuffer->m_errorBuffer[pBuffer->m_currentEnd] = '\0';
-
+		if (xnOSStrFormatV(pBuffer->m_errorBuffer + pBuffer->m_currentEnd, ms_bufferSize - pBuffer->m_currentEnd, &charsWritten, cpFormat, args) == XN_STATUS_OK)
+		{
+			pBuffer->m_currentEnd += charsWritten;
+			pBuffer->m_errorBuffer[pBuffer->m_currentEnd++] = '\n';
+			pBuffer->m_errorBuffer[pBuffer->m_currentEnd] = '\0';
+		}
+		else
+		{
+			pBuffer->m_currentEnd += charsWritten;
+		}
 	}
 
 	ErrorLogger::ErrorLogger()


### PR DESCRIPTION
Small bugfix. 
On Windows (at least), the ErrorLogger didn't correctly check if its internal buffer was full, possible causing an overflow+crash. 
That occurred, for example, on initialization, when the drivers directory contained a few additional DLLs which weren't OpenNI drivers. For each non-driver-DLL, an error message is stored in the ErrorLogger, without ever clearing it, quickly filling up the buffer.

This fixes that. When the buffer is full, no more messages are stored in the ErrorLogger (like it was supposed to work).